### PR TITLE
RocksDB (v7.0.0) now requires C++17 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ ifeq ($(BIND_LMDB), 1)
 	SOURCES += $(wildcard lmdb/*.cc)
 endif
 
-CXXFLAGS += -std=c++11 -Wall -pthread $(EXTRA_CXXFLAGS) -I./
+CXXFLAGS += -std=c++17 -Wall -pthread $(EXTRA_CXXFLAGS) -I./
 LDFLAGS += $(EXTRA_LDFLAGS) -lpthread
 SOURCES += $(wildcard core/*.cc)
 OBJECTS += $(SOURCES:.cc=.o)


### PR DESCRIPTION
RocksDB (v7.0.0) now requires C++17 support