### PR TITLE
leveldb properties option bug fix

### DIFF
--- a/leveldb/leveldb.properties
+++ b/leveldb/leveldb.properties
@@ -8,3 +8,5 @@ leveldb.max_open_files=1000
 leveldb.compression=snappy
 leveldb.cache_size=134217728
 leveldb.filter_bits=10
+
+# Compression option only supports snappy.

--- a/leveldb/leveldb_db.cc
+++ b/leveldb/leveldb_db.cc
@@ -28,19 +28,19 @@ namespace {
   const std::string PROP_COMPRESSION_DEFAULT = "no";
 
   const std::string PROP_WRITE_BUFFER_SIZE = "leveldb.write_buffer_size";
-  const std::string PROP_WRITE_BUFFER_SIZE_DEFAULT = "-1";
+  const std::string PROP_WRITE_BUFFER_SIZE_DEFAULT = "0";
 
   const std::string PROP_MAX_FILE_SIZE = "leveldb.max_file_size";
-  const std::string PROP_MAX_FILE_SIZE_DEFAULT = "-1";
+  const std::string PROP_MAX_FILE_SIZE_DEFAULT = "0";
 
   const std::string PROP_MAX_OPEN_FILES = "leveldb.max_open_files";
-  const std::string PROP_MAX_OPEN_FILES_DEFAULT = "-1";
+  const std::string PROP_MAX_OPEN_FILES_DEFAULT = "0";
 
   const std::string PROP_CACHE_SIZE = "leveldb.cache_size";
-  const std::string PROP_CACHE_SIZE_DEFAULT = "-1";
+  const std::string PROP_CACHE_SIZE_DEFAULT = "0";
 
   const std::string PROP_FILTER_BITS = "leveldb.filter_bits";
-  const std::string PROP_FILTER_BITS_DEFAULT = "-1";
+  const std::string PROP_FILTER_BITS_DEFAULT = "0";
 } // anonymous
 
 namespace ycsbc {
@@ -132,7 +132,7 @@ void LeveldbDB::GetOptions(const utils::Properties &props, leveldb::Options *opt
   }
   size_t cache_size = std::stol(props.GetProperty(PROP_CACHE_SIZE,
                                                   PROP_CACHE_SIZE_DEFAULT));
-  if (cache_size >= 0) {
+  if (cache_size > 0) {
     opt->block_cache = leveldb::NewLRUCache(cache_size);
   }
   int max_open_files = std::stoi(props.GetProperty(PROP_MAX_OPEN_FILES,


### PR DESCRIPTION
Existing Leveldb properties options had a "Integer underflow" bug on default values. 
```c++
size_t cache_size = std::stol(props.GetProperty(PROP_CACHE_SIZE, PROP_CACHE_SIZE_DEFAULT))
```
When we use default option of cache, r-value is long(-1).  
But type size_t doesn't support negative value, therefore "Integer underflow" occurs.

Thanks.