### PR TITLE
Add previously unsupported leveldb properties

### DIFF
--- a/leveldb/leveldb.properties
+++ b/leveldb/leveldb.properties
@@ -8,3 +8,5 @@ leveldb.max_open_files=1000
 leveldb.compression=snappy
 leveldb.cache_size=134217728
 leveldb.filter_bits=10
+leveldb.block_size=4096
+leveldb.block_restart_interval=16

--- a/leveldb/leveldb_db.cc
+++ b/leveldb/leveldb_db.cc
@@ -158,19 +158,16 @@ void LeveldbDB::GetOptions(const utils::Properties &props, leveldb::Options *opt
   if (filter_bits > 0) {
     opt->filter_policy = leveldb::NewBloomFilterPolicy(filter_bits);
   }
-
   int block_size = std::stoi(props.GetProperty(PROP_BLOCK_SIZE,
                                                PROP_BLOCK_SIZE_DEFAULT)); 
   if (block_size > 0) {
     opt->block_size = block_size;
   }
-
   int block_restart_interval = std::stoi(props.GetProperty(PROP_BLOCK_RESTART_INTERVAL,
                                                 PROP_BLOCK_RESTART_INTERVAL_DEFAULT));
   if (block_restart_interval > 0) {
     opt->block_restart_interval = block_restart_interval;
   }
-
 }
 
 void LeveldbDB::SerializeRow(const std::vector<Field> &values, std::string *data) {

--- a/leveldb/leveldb_db.cc
+++ b/leveldb/leveldb_db.cc
@@ -41,6 +41,12 @@ namespace {
 
   const std::string PROP_FILTER_BITS = "leveldb.filter_bits";
   const std::string PROP_FILTER_BITS_DEFAULT = "0";
+
+  const std::string PROP_BLOCK_SIZE = "leveldb.block_size";
+  const std::string PROP_BLOCK_SIZE_DEFAULT = "0";
+
+  const std::string PROP_BLOCK_RESTART_INTERVAL = "leveldb.block_restart_interval";
+  const std::string PROP_BLOCK_RESTART_INTERVAL_DEFAULT = "0";
 } // anonymous
 
 namespace ycsbc {
@@ -152,6 +158,19 @@ void LeveldbDB::GetOptions(const utils::Properties &props, leveldb::Options *opt
   if (filter_bits > 0) {
     opt->filter_policy = leveldb::NewBloomFilterPolicy(filter_bits);
   }
+
+  int block_size = std::stoi(props.GetProperty(PROP_BLOCK_SIZE,
+                                               PROP_BLOCK_SIZE_DEFAULT)); 
+  if (block_size > 0) {
+    opt->block_size = block_size;
+  }
+
+  int block_restart_interval = std::stoi(props.GetProperty(PROP_BLOCK_RESTART_INTERVAL,
+                                                PROP_BLOCK_RESTART_INTERVAL_DEFAULT));
+  if (block_restart_interval > 0) {
+    opt->block_restart_interval = block_restart_interval;
+  }
+
 }
 
 void LeveldbDB::SerializeRow(const std::vector<Field> &values, std::string *data) {


### PR DESCRIPTION
I added **block_size** and **block_restart_interval options** in leveldb properties which were previously unsupported.