### PR TITLE
fix item_count of ScrambledZipfianGenerator

### DIFF
--- a/core/scrambled_zipfian_generator.h
+++ b/core/scrambled_zipfian_generator.h
@@ -20,11 +20,11 @@ namespace ycsbc {
 class ScrambledZipfianGenerator : public Generator<uint64_t> {
  public:
   ScrambledZipfianGenerator(uint64_t min, uint64_t max, double zipfian_const) :
-      base_(min), num_items_(max - min + 1), generator_(0, 10000000000LL, zipfian_const) { }
+      base_(min), num_items_(max - min + 1), generator_(0, max - min + 1, zipfian_const) { }
 
   ScrambledZipfianGenerator(uint64_t min, uint64_t max) :
       base_(min), num_items_(max - min + 1),
-      generator_(0, 10000000000LL, ZipfianGenerator::kZipfianConst, kZetan) { }
+      generator_(0, max - min + 1, ZipfianGenerator::kZipfianConst, kZetan) { }
 
   ScrambledZipfianGenerator(uint64_t num_items) :
       ScrambledZipfianGenerator(0, num_items - 1) { }


### PR DESCRIPTION
Hello,
The generator_ of ScrambledZipfianGenerator is incorrectly initialized.
If $min and $max is declared in the constructor, the $item_count should be $max - $min + 1, not 10000000000LL.
You can check the original YCSB source code in the following link below.
(https://github.com/brianfrankcooper/YCSB/blob/master/core/src/main/java/site/ycsb/generator/ScrambledZipfianGenerator.java#L87)