### PR TITLE
Fix compressed block cache for RocksDB binding

### DIFF
--- a/rocksdb/rocksdb_db.cc
+++ b/rocksdb/rocksdb_db.cc
@@ -335,8 +335,8 @@ void RocksdbDB::GetOptions(const utils::Properties &props, rocksdb::Options *opt
     size_t compressed_cache_size = std::stoul(props.GetProperty(PROP_COMPRESSED_CACHE_SIZE,
                                                                 PROP_COMPRESSED_CACHE_SIZE_DEFAULT));
     if (compressed_cache_size > 0) {
-      block_cache_compressed = rocksdb::NewLRUCache(cache_size);
-      table_options.block_cache_compressed = rocksdb::NewLRUCache(compressed_cache_size);
+      block_cache_compressed = rocksdb::NewLRUCache(compressed_cache_size);
+      table_options.block_cache_compressed = block_cache_compressed;
     }
     int bloom_bits = std::stoul(props.GetProperty(PROP_BLOOM_BITS, PROP_BLOOM_BITS_DEFAULT));
     if (bloom_bits > 0) {


### PR DESCRIPTION
`block_cache_compressed` should be created with `compressed_cache_size` instead of `cache_size`.

Also `table_options.block_cache_compressed` should be assigned to the static `block_cache_compressed` rather than creating a new one.