### PR TITLE
Fixing unreleased column_family ref when using options.ini for rocksdb

### DIFF
--- a/rocksdb/rocksdb_db.cc
+++ b/rocksdb/rocksdb_db.cc
@@ -218,15 +218,15 @@ void RocksdbDB::Init() {
 }
 
 void RocksdbDB::Cleanup() { 
+  const std::lock_guard<std::mutex> lock(mu_);
+  if (--ref_cnt_) {
+    return;
+  }
   for (size_t i = 0; i < cf_handles_.size(); i++) {
     if (cf_handles_[i] != nullptr) {
       delete cf_handles_[i];
       cf_handles_[i] = nullptr;
     }
-  }
-  const std::lock_guard<std::mutex> lock(mu_);
-  if (--ref_cnt_) {
-    return;
   }
   delete db_;
 }

--- a/rocksdb/rocksdb_db.cc
+++ b/rocksdb/rocksdb_db.cc
@@ -195,7 +195,6 @@ void RocksdbDB::Init() {
   rocksdb::Options opt;
   opt.create_if_missing = true;
   std::vector<rocksdb::ColumnFamilyDescriptor> cf_descs;
-  std::vector<rocksdb::ColumnFamilyHandle *> cf_handles;
   GetOptions(props, &opt, &cf_descs);
 #ifdef USE_MERGEUPDATE
   opt.merge_operator.reset(new YCSBUpdateMerge);
@@ -211,14 +210,20 @@ void RocksdbDB::Init() {
   if (cf_descs.empty()) {
     s = rocksdb::DB::Open(opt, db_path, &db_);
   } else {
-    s = rocksdb::DB::Open(opt, db_path, cf_descs, &cf_handles, &db_);
+    s = rocksdb::DB::Open(opt, db_path, cf_descs, &cf_handles_, &db_);
   }
   if (!s.ok()) {
     throw utils::Exception(std::string("RocksDB Open: ") + s.ToString());
   }
 }
 
-void RocksdbDB::Cleanup() {
+void RocksdbDB::Cleanup() { 
+  for (size_t i = 0; i < cf_handles_.size(); i++) {
+    if (cf_handles_[i] != nullptr) {
+      delete cf_handles_[i];
+      cf_handles_[i] = nullptr;
+    }
+  }
   const std::lock_guard<std::mutex> lock(mu_);
   if (--ref_cnt_) {
     return;

--- a/rocksdb/rocksdb_db.h
+++ b/rocksdb/rocksdb_db.h
@@ -92,6 +92,7 @@ class RocksdbDB : public DB {
 
   int fieldcount_;
 
+  std::vector<rocksdb::ColumnFamilyHandle *> cf_handles_;
   static rocksdb::DB *db_;
   static int ref_cnt_;
   static std::mutex mu_;

--- a/rocksdb/rocksdb_db.h
+++ b/rocksdb/rocksdb_db.h
@@ -92,7 +92,7 @@ class RocksdbDB : public DB {
 
   int fieldcount_;
 
-  std::vector<rocksdb::ColumnFamilyHandle *> cf_handles_;
+  static std::vector<rocksdb::ColumnFamilyHandle *> cf_handles_;
   static rocksdb::DB *db_;
   static int ref_cnt_;
   static std::mutex mu_;


### PR DESCRIPTION
When specifying 'options.ini' to benchmark rocksdb, there would be an assertion error because the column family refs are not fully released yet. For example, `/ycsb -load -run -db rocksdb -P workloads/workloadb -p rocksdb.optionsfile=rocksdb/options.ini` ends up with the following assertion error:
```
db/column_family.cc:1618: rocksdb::ColumnFamilySet::~ColumnFamilySet(): Assertion `last_ref' failed.
```

This commit makes the cf_handles a private member of the rocksdb instance and releases the refs by deleting the pointers stored in cf_handles. 